### PR TITLE
Fix Flux deprecations and example files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FluxArchitectures"
 uuid = "53d20848-f986-4c56-957e-0e417ec068db"
 authors = ["Sören Dobberschütz <sdobberschuetz@gmx.net> and contributors"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"

--- a/README.md
+++ b/README.md
@@ -55,5 +55,5 @@ loss(x, y) = Flux.mse(model(x), y')
 
 Train the model:
 ```julia
-Flux.train!(loss, Flux.params(model),Iterators.repeated((input, target), 20), ADAM(0.01))
+Flux.train!(loss, Flux.params(model),Iterators.repeated((input, target), 20), Adam(0.01))
 ```

--- a/benchmark/Benchmarks.jl
+++ b/benchmark/Benchmarks.jl
@@ -8,7 +8,8 @@ const RUN_CPU = true
 
 # Make sure all the required packages are available
 cd(@__DIR__)
-using Pkg; Pkg.activate(".")
+using Pkg;
+Pkg.activate(".");
 Pkg.instantiate()
 
 @info "Loading packages"
@@ -36,26 +37,26 @@ end
 
 ## DARNN ----------------------------------
 @info "DARNN"
-push!(results,["DARNN", missing, missing])
+push!(results, ["DARNN", missing, missing])
 encodersize = 10
 decodersize = 10
 if RUN_GPU
     model = DARNN(inputsize, encodersize, decodersize, poollength, 1) |> gpu
-    time = @belapsed Flux.train!(loss, Flux.params(model),Iterators.repeated((input_gpu, target_gpu), 5),
-            ADAM(0.007))
-    results[end,:GPU] = time
+    time = @belapsed Flux.train!(loss, Flux.params(model), Iterators.repeated((input_gpu, target_gpu), 5),
+        Adam(0.007))
+    results[end, :GPU] = time
 end
 if RUN_CPU
     model = DARNN(inputsize, encodersize, decodersize, poollength, 1)
-    time = @belapsed Flux.train!(loss, Flux.params(model),Iterators.repeated((input_cpu, target_cpu), 5),
-            ADAM(0.007))
-    results[end,:CPU] = time
+    time = @belapsed Flux.train!(loss, Flux.params(model), Iterators.repeated((input_cpu, target_cpu), 5),
+        Adam(0.007))
+    results[end, :CPU] = time
 end
 
 
 ## DSANet ----------------------------------
 @info "DSANet"
-push!(results,["DSANet", missing, missing])
+push!(results, ["DSANet", missing, missing])
 local_length = 3
 n_kernels = 3
 d_model = 4
@@ -65,59 +66,59 @@ n_head = 2
 if RUN_GPU
     Random.seed!(123)
     model = DSANet(inputsize, poollength, local_length, n_kernels, d_model,
-               hiddensize, n_layers, n_head) |> gpu
-    time = @belapsed Flux.train!(loss, Flux.params(model),Iterators.repeated((input_gpu, target_gpu), 5),
-            ADAM(0.007))
-    results[end,:GPU] = time
+        hiddensize, n_layers, n_head) |> gpu
+    time = @belapsed Flux.train!(loss, Flux.params(model), Iterators.repeated((input_gpu, target_gpu), 5),
+        Adam(0.007))
+    results[end, :GPU] = time
 end
 if RUN_CPU
     Random.seed!(123)
     model = DSANet(inputsize, poollength, local_length, n_kernels, d_model,
-               hiddensize, n_layers, n_head)
-    time = @belapsed Flux.train!(loss, Flux.params(model),Iterators.repeated((input_cpu, target_cpu), 5),
-            ADAM(0.007))
-    results[end,:CPU] = time
+        hiddensize, n_layers, n_head)
+    time = @belapsed Flux.train!(loss, Flux.params(model), Iterators.repeated((input_cpu, target_cpu), 5),
+        Adam(0.007))
+    results[end, :CPU] = time
 end
 
 
 ## LSTNet ----------------------------------
 @info "LSTNet"
-push!(results,["LSTNet", missing, missing])
+push!(results, ["LSTNet", missing, missing])
 convlayersize = 2
 recurlayersize = 3
 skiplength = 120
 if RUN_GPU
     model = LSTnet(inputsize, convlayersize, recurlayersize, poollength, skiplength,
         init=Flux.zeros, initW=Flux.zeros) |> gpu
-    time = @belapsed Flux.train!(loss, Flux.params(model),Iterators.repeated((input_gpu, target_gpu), 5),
-            ADAM(0.007))
-    results[end,:GPU] = time
+    time = @belapsed Flux.train!(loss, Flux.params(model), Iterators.repeated((input_gpu, target_gpu), 5),
+        Adam(0.007))
+    results[end, :GPU] = time
 end
 if RUN_CPU
     model = LSTnet(inputsize, convlayersize, recurlayersize, poollength, skiplength,
         init=Flux.zeros, initW=Flux.zeros)
-    time = @belapsed Flux.train!(loss, Flux.params(model),Iterators.repeated((input_cpu, target_cpu), 5),
-            ADAM(0.007))
-    results[end,:CPU] = time
+    time = @belapsed Flux.train!(loss, Flux.params(model), Iterators.repeated((input_cpu, target_cpu), 5),
+        Adam(0.007))
+    results[end, :CPU] = time
 end
 
 
 ## TPA-LSTM ----------------------------------
 @info "TPA-LSTM"
-push!(results,["TPA-LSTM", missing, missing])
+push!(results, ["TPA-LSTM", missing, missing])
 hiddensize = 10
 layers = 2
 filternum = 32
 filtersize = 1
 if RUN_GPU
     model = TPALSTM(inputsize, hiddensize, poollength, layers, filternum, filtersize) |> gpu
-    time = @belapsed Flux.train!(loss, Flux.params(model),Iterators.repeated((input_gpu, target_gpu), 5),
-            ADAM(0.007))
-    results[end,:GPU] = time
+    time = @belapsed Flux.train!(loss, Flux.params(model), Iterators.repeated((input_gpu, target_gpu), 5),
+        Adam(0.007))
+    results[end, :GPU] = time
 end
 if RUN_CPU
     model = TPALSTM(inputsize, hiddensize, poollength, layers, filternum, filtersize)
-    time = @belapsed Flux.train!(loss, Flux.params(model),Iterators.repeated((input_cpu, target_cpu), 5),
-            ADAM(0.007))
-    results[end,:CPU] = time
+    time = @belapsed Flux.train!(loss, Flux.params(model), Iterators.repeated((input_cpu, target_cpu), 5),
+        Adam(0.007))
+    results[end, :CPU] = time
 end

--- a/docs/src/examples/examples.md
+++ b/docs/src/examples/examples.md
@@ -24,7 +24,9 @@ skiplength = 120
 model = LSTnet(inputsize, convlayersize, recurlayersize, poollength, skiplength, init=Flux.zeros32, initW=Flux.zeros32) |> gpu
 
 function loss(x, y)
-    Flux.reset!(model)
+    Flux.ChainRulesCore.ignore_derivatives() do
+        Flux.reset!(model)
+    end
     return Flux.mse(model(x), y')
 end
 
@@ -39,7 +41,7 @@ end
 
 @info "Start loss" loss = loss(input, target)
 @info "Starting training"
-Flux.train!(loss, Flux.params(model),Iterators.repeated((input, target), 20), ADAM(0.01), cb=cb)
+Flux.train!(loss, Flux.params(model),Iterators.repeated((input, target), 20), Adam(0.01), cb=cb)
 @info "Final loss" loss = loss(input, target)
 ```
 
@@ -73,10 +75,12 @@ skiplength = 120
 model = LSTnet(inputsize, convlayersize, recurlayersize, poollength, skiplength, init=Flux.zeros32, initW=Flux.zeros32) |> gpu
 ```
 
-As the loss function, we use the standard mean squared error loss. To make sure to reset the hidden state for each training loop, we call `Flux.reset!` every time we calculate the loss.
+As the loss function, we use the standard mean squared error loss. To make sure to reset the hidden state for each training loop, we call `Flux.reset!` every time we calculate the loss, and wrap it in `ignore_derivatives()` to exclude the model reset from the derivative calculation.
 ```julia
 function loss(x, y)
-    Flux.reset!(model)
+    Flux.ChainRulesCore.ignore_derivatives() do
+        Flux.reset!(model)
+    end
     return Flux.mse(model(x), y')
 end
 ```
@@ -103,7 +107,7 @@ Finally, we start the training loop and train for 20 epochs.
 @info "Start loss" loss = loss(input, target)
 @info "Starting training"
 Flux.train!(loss, Flux.params(model),Iterators.repeated((input, target), 20),
-            ADAM(0.01), cb=cb)
+            Adam(0.01), cb=cb)
 @info "Final loss" loss = loss(input, target)
 ```
 
@@ -125,7 +129,7 @@ decodersize = 10
 
 model = DARNN(inputsize, encodersize, decodersize, poollength, 1) |> gpu
 ```
-and train with `ADAM(0.007)` as optimizer.
+and train with `Adam(0.007)` as optimizer.
 
 
 ## DSANet Example
@@ -148,7 +152,7 @@ n_head = 2
 Random.seed!(123)
 model = DSANet(inputsize, poollength, local_length, n_kernels, d_model, hiddensize, n_layers, n_head) |> gpu
 ```
-Use `ADAM(0.005)` as optimizer.
+Use `Adam(0.005)` as optimizer.
 
 
 ## TPALSTM Example
@@ -168,4 +172,4 @@ filtersize = 1
 
 model = TPALSTM(inputsize, hiddensize, poollength, layers, filternum, filtersize) |> gpu
 ```
-Train with `ADAM(0.02)`.
+Train with `Adam(0.02)`.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -44,5 +44,5 @@ loss(x, y) = Flux.mse(model(x), y')
 
 Train the model:
 ```julia
-Flux.train!(loss, Flux.params(model),Iterators.repeated((input, target), 20), ADAM(0.01))
+Flux.train!(loss, Flux.params(model),Iterators.repeated((input, target), 20), Adam(0.01))
 ```

--- a/examples/Example_DARNN.jl
+++ b/examples/Example_DARNN.jl
@@ -2,7 +2,8 @@
 
 # Make sure all the required packages are available
 cd(@__DIR__)
-using Pkg; Pkg.activate(".") 
+using Pkg;
+Pkg.activate(".");
 Pkg.instantiate()
 
 @info "Loading packages"
@@ -28,7 +29,9 @@ model = DARNN(inputsize, encodersize, decodersize, poollength, 1) |> gpu
 
 # MSE loss
 function loss(x, y)
-    Flux.reset!(model)
+    Flux.ChainRulesCore.ignore_derivatives() do
+        Flux.reset!(model)
+    end
     return Flux.mse(model(x), permutedims(y))
 end
 
@@ -45,8 +48,8 @@ end
 # Training loop
 @info "Start loss" loss = loss(input, target)
 @info "Starting training"
-Flux.train!(loss, Flux.params(model),Iterators.repeated((input, target), 10),
-            ADAM(0.007), cb=cb)
+Flux.train!(loss, Flux.params(model), Iterators.repeated((input, target), 10),
+    Adam(0.007), cb=cb)
 
 @info "Finished"
 @info "Final loss" loss = loss(input, target)

--- a/examples/Example_DSANet.jl
+++ b/examples/Example_DSANet.jl
@@ -35,7 +35,9 @@ model = DSANet(inputsize, poollength, local_length, n_kernels, d_model,
 
 # MSE loss
 function loss(x, y)
-    Flux.reset!(model)
+    Flux.ChainRulesCore.ignore_derivatives() do
+        Flux.reset!(model)
+    end
     return Flux.mse(model(x), permutedims(y))
 end
 
@@ -53,7 +55,7 @@ end
 @info "Starting training"
 @info "Start loss" loss = loss(input, target)
 Flux.train!(loss, Flux.params(model), Iterators.repeated((input, target), 50),
-    ADAM(0.005), cb=cb)
+    Adam(0.005), cb=cb)
 
 @info "Finished"
 @info "Final loss" loss = loss(input, target)

--- a/examples/Example_LSTNet.jl
+++ b/examples/Example_LSTNet.jl
@@ -26,11 +26,13 @@ skiplength = 120
 
 # Define the neural net
 model = LSTnet(inputsize, convlayersize, recurlayersize, poollength, skiplength,
-    init = Flux.zeros32, initW = Flux.zeros32) |> gpu
+    init=Flux.zeros32, initW=Flux.zeros32) |> gpu
 
 # MSE loss
 function loss(x, y)
-    Flux.reset!(model)
+    Flux.ChainRulesCore.ignore_derivatives() do
+        Flux.reset!(model)
+    end
     return Flux.mse(model(x), permutedims(y))
 end
 
@@ -39,8 +41,8 @@ cb = function ()
     Flux.reset!(model)
     pred = model(input) |> permutedims |> cpu
     Flux.reset!(model)
-    p1 = plot(pred, label = "Predict")
-    p1 = plot!(cpu(target), label = "Data", title = "Loss $(loss(input, target))")
+    p1 = plot(pred, label="Predict")
+    p1 = plot!(cpu(target), label="Data", title="Loss $(loss(input, target))")
     display(plot(p1))
 end
 
@@ -48,7 +50,7 @@ end
 @info "Start loss" loss = loss(input, target)
 @info "Starting training"
 Flux.train!(loss, Flux.params(model), Iterators.repeated((input, target), 20),
-    ADAM(0.01), cb = cb)
+    Adam(0.01), cb=cb)
 
 @info "Finished"
 @info "Final loss" loss = loss(input, target)

--- a/examples/Example_TPALSTM.jl
+++ b/examples/Example_TPALSTM.jl
@@ -30,7 +30,9 @@ model = TPALSTM(inputsize, hiddensize, poollength, layers, filternum, filtersize
 
 # MSE loss
 function loss(x, y)
-    Flux.reset!(model)
+    Flux.ChainRulesCore.ignore_derivatives() do
+        Flux.reset!(model)
+    end
     return Flux.mse(model(x), permutedims(y))
 end
 
@@ -39,8 +41,8 @@ cb = function ()
     Flux.reset!(model)
     pred = model(input) |> permutedims |> cpu
     Flux.reset!(model)
-    p1 = plot(pred, label = "Predict")
-    p1 = plot!(cpu(target), label = "Data", title = "Loss $(loss(input, target))")
+    p1 = plot(pred, label="Predict")
+    p1 = plot!(cpu(target), label="Data", title="Loss $(loss(input, target))")
     display(plot(p1))
 end
 
@@ -48,7 +50,7 @@ end
 @info "Start loss" loss = loss(input, target)
 @info "Starting training"
 Flux.train!(loss, Flux.params(model), Iterators.repeated((input, target), 50),
-    ADAM(0.02), cb = cb)
+    Adam(0.02), cb=cb)
 
 @info "Finished"
 @info "Final loss" loss = loss(input, target)

--- a/src/DARNN.jl
+++ b/src/DARNN.jl
@@ -7,32 +7,32 @@
 # Struct that stores layers and some extra information
 mutable struct DARNNCell{A,B,C,D,E,F,W,X,Y,Z}
     # Encoder part
-	encoder_lstm::A
-	encoder_attn::B
+    encoder_lstm::A
+    encoder_attn::B
     # Decoder part
-	decoder_lstm::C
-	decoder_attn::D
-	decoder_fc::E
-	decoder_fc_final::F
+    decoder_lstm::C
+    decoder_attn::D
+    decoder_fc::E
+    decoder_fc_final::F
     # Index for original data etc
-	encodersize::W
-	decodersize::X
-	orig_idx::Y
-	poollength::Z
+    encodersize::W
+    decodersize::X
+    orig_idx::Y
+    poollength::Z
 end
 
 # Initialization function to obtain the right size of the hidden state
 # after a `reset!` of the model.
 function darnn_init(m::DARNNCell, x)
-	s = size(x)
-	m.encoder_lstm(simarray(x, s[1], s[4]))
-	m.decoder_lstm(simarray(x, 1, s[4]))
-	return nothing
+    s = size(x)
+    m.encoder_lstm(simarray(x, s[1], s[4]))
+    m.decoder_lstm(simarray(x, 1, s[4]))
+    return nothing
 end
 simarray(x::Flux.CUDA.CuArray, size...) = Flux.CUDA.zeros(eltype(x), size...)
 simarray(x, size...) = zeros(eltype(x), size...)
 
-Flux.Zygote.@nograd darnn_init
+Flux.ChainRulesCore.@non_differentiable darnn_init(m, x)
 
 # Dispatch on `trainable` and `reset!` to make standard Flux scripts work
 Flux.trainable(m::DARNNCell) = (m.encoder_lstm, m.encoder_attn, m.decoder_lstm,
@@ -59,94 +59,95 @@ Takes the keyword arguments `init` and `bias` for the initialization of the
 weight vector and bias of the linear layers.
 """
 function DARNN(inp::Integer, encodersize::Integer, decodersize::Integer, poollength::Integer, orig_idx::Integer;
-	init=Flux.glorot_uniform, bias=true)
+    init=Flux.glorot_uniform, bias=true)
 
-	# Encoder part
-	encoder_lstm = Seq(HiddenRecur(Flux.LSTMCell(inp, encodersize)))
-	encoder_attn = Chain(Dense(2 * encodersize + poollength, poollength, init=init, bias=bias),
-	                    a -> tanh.(a),
-	                    Dense(poollength, 1, init=init, bias=bias))
-	# Decoder part
-	decoder_lstm = Seq(HiddenRecur(Flux.LSTMCell(1, decodersize)))
-	decoder_attn = Chain(Dense(2 * decodersize + encodersize, encodersize, init=init, bias=bias),
-	                    a -> tanh.(a),
-	                    Dense(encodersize, 1, init=init, bias=bias))
-	decoder_fc = Dense(encodersize + 1, 1)
-	decoder_fc_final = Dense(decodersize + encodersize, 1, init=init, bias=bias)
+    # Encoder part
+    encoder_lstm = Seq(HiddenRecur(Flux.LSTMCell(inp, encodersize)))
+    encoder_attn = Chain(Dense(2 * encodersize + poollength, poollength, init=init, bias=bias),
+        a -> tanh.(a),
+        Dense(poollength, 1, init=init, bias=bias))
+    # Decoder part
+    decoder_lstm = Seq(HiddenRecur(Flux.LSTMCell(1, decodersize)))
+    decoder_attn = Chain(Dense(2 * decodersize + encodersize, encodersize, init=init, bias=bias),
+        a -> tanh.(a),
+        Dense(encodersize, 1, init=init, bias=bias))
+    decoder_fc = Dense(encodersize + 1, 1)
+    decoder_fc_final = Dense(decodersize + encodersize, 1, init=init, bias=bias)
 
-	return DARNNCell(encoder_lstm, encoder_attn, decoder_lstm, decoder_attn, decoder_fc,
-	 		  decoder_fc_final, encodersize, decodersize, orig_idx, poollength)
+    return DARNNCell(encoder_lstm, encoder_attn, decoder_lstm, decoder_attn, decoder_fc,
+        decoder_fc_final, encodersize, decodersize, orig_idx, poollength)
 end
 
 # model output
 function (m::DARNNCell)(x)
-	# Initialize after reset
-	size(m.encoder_lstm.state, 1) == 1 && darnn_init(m, x)
-	input_data = dropdims(x; dims=3)
-	input_encoded = darnn_encoder(m, input_data)
-	context = darnn_decoder(m, input_encoded, input_data)
-	return m.decoder_fc_final(cat(m.decoder_lstm.state[1], context, dims=1))
+    # Initialize after reset
+    size(m.encoder_lstm.state, 1) == 1 && darnn_init(m, x)
+    input_data = dropdims(x; dims=3)
+    input_encoded = darnn_encoder(m, input_data)
+    context = darnn_decoder(m, input_encoded, input_data)
+    return m.decoder_fc_final(cat(m.decoder_lstm.state[1], context, dims=1))
 end
 
 function _encoder(m::DARNNCell, input_data, slice)
-	hidden = m.encoder_lstm.state[1]
-	cell = m.encoder_lstm.state[2]
-	repeatmat = darnn_getones(input_data)
+    hidden = m.encoder_lstm.state[1]
+    cell = m.encoder_lstm.state[2]
+    repeatmat = darnn_getones(input_data)
 
-	x = cat(hidden .* repeatmat, cell .* repeatmat,  # CUDA compatible repeat(hidden, inner=(1,1,size(input_data,1)) etc.
-			permutedims(input_data, [2,3,1]), dims=1)  |>
-		a -> m.encoder_attn(reshape(a, (:, size(input_data, 1) * size(input_data, 3))))
-	attn_weights = Flux.softmax(reshape(x, (size(input_data, 1), size(input_data, 3))))
-	weighted_input = attn_weights .* slice
-	_ = m.encoder_lstm(weighted_input)
-	return m.encoder_lstm.state[1]
+    x = cat(hidden .* repeatmat, cell .* repeatmat,  # CUDA compatible repeat(hidden, inner=(1,1,size(input_data,1)) etc.
+        permutedims(input_data, [2, 3, 1]), dims=1) |>
+        a -> m.encoder_attn(reshape(a, (:, size(input_data, 1) * size(input_data, 3))))
+    attn_weights = Flux.softmax(reshape(x, (size(input_data, 1), size(input_data, 3))))
+    weighted_input = attn_weights .* slice
+    _ = m.encoder_lstm(weighted_input)
+    return m.encoder_lstm.state[1]
 end
 
 function darnn_encoder(m::DARNNCell, input_data::Array)
-	sl = Slices(input_data, True(), False(), True())
-	fun = s -> _encoder(m, input_data, s)
-	return Align(map(fun, sl), True(), False(), True())
+    sl = Slices(input_data, True(), False(), True())
+    fun = s -> _encoder(m, input_data, s)
+    return Align(map(fun, sl), True(), False(), True())
 end
 
 function darnn_encoder(m::DARNNCell, input_data::Flux.CUDA.CuArray)
-	input_encoded = Flux.Zygote.Buffer(input_data, m.encodersize, m.poollength,
-	 				size(input_data, 3))
-	@inbounds for t in 1:m.poollength
-	      input_encoded[:,t,:] = Flux.unsqueeze(_encoder(m, input_data, input_data[:,t,:]), dims = 2)
-	end
-	return copy(input_encoded)
+    input_encoded = Flux.Zygote.Buffer(input_data, m.encodersize, m.poollength,
+        size(input_data, 3))
+    @inbounds for t in 1:m.poollength
+        input_encoded[:, t, :] = Flux.unsqueeze(_encoder(m, input_data, input_data[:, t, :]), dims=2)
+    end
+    return copy(input_encoded)
 end
 
 function darnn_decoder(m::DARNNCell, input_encoded, input_data)
-	context = Flux.zeros32(m.encodersize, size(input_data, 3))
-	@inbounds for t in 1:m.poollength
-	      hidden = m.decoder_lstm.state[1]
-		  cell = m.decoder_lstm.state[2]
-		  repeatmat = darnn_getones(input_data, m.poollength)
-	      x = cat(permutedims(hidden .* repeatmat, [1,3,2]),
-	              permutedims(cell .* repeatmat, [1,3,2]),
-	              input_encoded, dims=1) |>
-	          a -> m.decoder_attn(reshape(a, (2 * m.decodersize + m.encodersize, :))) |>
-	          a -> Flux.softmax(reshape(a, (m.poollength, :)))
-	      context = dropdims(NNlib.batched_mul(input_encoded, Flux.unsqueeze(x, dims = 2)), dims=2)
-	      ỹ = m.decoder_fc(cat(context, input_data[m.orig_idx,t,:]', dims=1))
-	      _ = m.decoder_lstm(ỹ)
-	end
-	return context
+    context = Flux.zeros32(m.encodersize, size(input_data, 3))
+    @inbounds for t in 1:m.poollength
+        hidden = m.decoder_lstm.state[1]
+        cell = m.decoder_lstm.state[2]
+        repeatmat = darnn_getones(input_data, m.poollength)
+        x = cat(permutedims(hidden .* repeatmat, [1, 3, 2]),
+            permutedims(cell .* repeatmat, [1, 3, 2]),
+            input_encoded, dims=1) |>
+            a -> m.decoder_attn(reshape(a, (2 * m.decodersize + m.encodersize, :))) |>
+                 a -> Flux.softmax(reshape(a, (m.poollength, :)))
+        context = dropdims(NNlib.batched_mul(input_encoded, Flux.unsqueeze(x, dims=2)), dims=2)
+        ỹ = m.decoder_fc(cat(context, input_data[m.orig_idx, t, :]', dims=1))
+        _ = m.decoder_lstm(ỹ)
+    end
+    return context
 end
 
 # pretty printing
 function Base.show(io::IO, l::DARNNCell)
-	print(io, "DARNN(", size(l.encoder_lstm.chain.cell.Wi, 2))
-	print(io, ", ", l.encodersize)
-	print(io, ", ", Int(size(l.decoder_lstm.chain.cell.Wi, 1) / 4))
-	print(io, ", ", l.poollength)
-	print(io, ", ", l.orig_idx)
-	print(io, ")")
+    print(io, "DARNN(", size(l.encoder_lstm.chain.cell.Wi, 2))
+    print(io, ", ", l.encodersize)
+    print(io, ", ", Int(size(l.decoder_lstm.chain.cell.Wi, 1) / 4))
+    print(io, ", ", l.poollength)
+    print(io, ", ", l.orig_idx)
+    print(io, ")")
 end
 
 # Helper functions to replace `repeat` with CUDA friendly version
 darnn_getones(x::Array, size) = Flux.ones32(1, 1, size)
 darnn_getones(x::Flux.CUDA.CuArray, size) = Flux.CUDA.ones(1, 1, size)
 darnn_getones(x) = darnn_getones(x, size(x, 1))
-Flux.Zygote.@nograd darnn_getones
+Flux.ChainRulesCore.@non_differentiable darnn_getones(x, sz)
+Flux.ChainRulesCore.@non_differentiable darnn_getones(x)


### PR DESCRIPTION
Change `ADAM` to `Adam`, replace `Flux.Zygote.@nograd` with `Flux.ChainRulesCore.@non_differentiable`, and update the examples with 
```
Flux.ChainRulesCore.ignore_derivatives() do
        Flux.reset!(model)
end
```
to avoid errors coming from differentiating through the `reset!`-call.